### PR TITLE
Improve performance and response time

### DIFF
--- a/prettify-math.el
+++ b/prettify-math.el
@@ -338,7 +338,9 @@ As syntax class is mostly exclusive."
   (setq pre-redisplay-functions (delq 'cursor-sensor--detect pre-redisplay-functions))
   (when (prettify-math-contains-block-delimiters-p)
     (setq font-lock-multiline t)
-    (add-hook 'font-lock-extend-region-functions #'prettify-math-extend-block-delimiter-region))
+    (add-hook 'font-lock-extend-region-functions
+              #'prettify-math-extend-block-delimiter-region
+              100 t))
   (font-lock-add-keywords nil prettify-math--keywords)
   (--> prettify-math--extra-properties
        (append it font-lock-extra-managed-props)


### PR DESCRIPTION
My experience with an org-mode file containing many mathjax snippets
has been that prettify-math mode takes greater than 30 seconds to
initialize and causes Emacs to operate within the buffer very
sluggishly. The code modification of this commit reduced the mode
initialization time to !just! 7 seconds and improved Emacs response
time greatly.
